### PR TITLE
Add event date to page title

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     
     <title>
-        HackEHS | Edison High School's High School Hackathon
+        HackEHS | May 14-15 | Edison High School's High School Hackathon
     </title>
     <link rel='stylesheet' href='css/bootstrap.min.css' />
     <link rel='stylesheet' href='font-awesome/css/font-awesome.min.css' />


### PR DESCRIPTION
You can do everyone a HUGE favor by putting dates in your homepage < title > tag. There are a handful of times where people end up visiting hackathon sites just to double-check when an event is happening. 

Feel free to implement this however you want, my PR is just a suggestion.

![image](https://cloud.githubusercontent.com/assets/607807/14770769/a85b2868-0a47-11e6-8104-69922939d4fc.png)
